### PR TITLE
Allowed the "license-header" ESLint rule. Fixed broken license headers across the project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,17 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global module */
+
 // Note: The ESLint configuration is mandatory for vue-cli.
 module.exports = {
-	"extends": "ckeditor5"
+	'extends': 'ckeditor5',
+	'rules': {
+		'ckeditor5-rules/license-header': [ 'error', { headerLines: [
+			'/**',
+			' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+			' * For licensing, see LICENSE.md.',
+			' */'
+		] } ]
+	}
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global module */
+/* eslint-env node */
 
 // Note: The ESLint configuration is mandatory for vue-cli.
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",
     "eslint": "^7.0.0",
-    "eslint-config-ckeditor5": "^3.0.0",
+    "eslint-config-ckeditor5": "^4.0.0",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^5.0.9",
     "karma-chai": "^0.1.0",
@@ -63,7 +63,8 @@
     "prerelease": "npm run build; if [ -n \"$(git status dist/ --porcelain)\" ]; then git add -u dist/ && git commit -m 'Internal: Build.'; fi",
     "release": "node ./scripts/release.js",
     "test": "node ./scripts/test.js",
-    "coverage": "node ./scripts/test.js --coverage"
+    "coverage": "node ./scripts/test.js --coverage",
+    "lint": "eslint --quiet \"**/*.js\""
   },
   "repository": {
     "type": "git",
@@ -77,5 +78,8 @@
   "bugs": {
     "url": "https://github.com/ckeditor/ckeditor5-vue2/issues"
   },
-  "homepage": "https://github.com/ckeditor/ckeditor5-vue2"
+  "homepage": "https://github.com/ckeditor/ckeditor5-vue2",
+  "eslintIgnore": [
+    "dist/**"
+  ]
 }

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -5,6 +5,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global require process */
+
 'use strict';
 
 require( '@ckeditor/ckeditor5-dev-env' )

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -5,7 +5,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global require process */
+/* eslint-env node */
 
 'use strict';
 

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -5,6 +5,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global require process */
+
 'use strict';
 
 require( '@ckeditor/ckeditor5-dev-env' )

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -5,7 +5,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global require process */
+/* eslint-env node */
 
 'use strict';
 

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global console */
+/* eslint-env node */
 
 import { debounce } from 'lodash-es';
 

--- a/tests/ckeditor.js
+++ b/tests/ckeditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global console, setTimeout */
+/* eslint-env node */
 
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';

--- a/tests/plugin/integration.js
+++ b/tests/plugin/integration.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
+/* eslint-env browser */
 
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. Fixed broken license headers across the project. See ckeditor/ckeditor5#11468.