### PR TITLE
Do not attach husky hooks when installing a repository as a dependency (instead of cloning)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^5.0.0",
+    "lint-staged": "^10.2.11",
     "lodash-es": "^4.17.11",
     "minimist": "^1.2.0",
     "mocha": "^10.1.0",
@@ -83,5 +84,10 @@
   "homepage": "https://github.com/ckeditor/ckeditor5-vue2",
   "eslintIgnore": [
     "dist/**"
-  ]
+  ],
+  "lint-staged": {
+    "**/*.js": [
+      "eslint --quiet"
+    ]
+  }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,4 +7,12 @@
 
 /* eslint-env node */
 
-require( 'husky' ).install();
+const path = require( 'path' );
+const fs = require( 'fs' );
+const ROOT_DIRECTORY = path.join( __dirname, '..' );
+
+// When installing a repository as a dependency, the `.git` directory does not exist.
+// In such a case, husky should not attach its hooks as npm treats it as a package, not a git repository.
+if ( fs.existsSync( path.join( ROOT_DIRECTORY, '.git' ) ) ) {
+	require( 'husky' ).install();
+}


### PR DESCRIPTION
Internal: Do not attach husky hooks when installing a repository as a dependency (instead of cloning)